### PR TITLE
Use correct type for C enumerations

### DIFF
--- a/CMarkGFM.hsc
+++ b/CMarkGFM.hsc
@@ -640,16 +640,16 @@ foreign import ccall "cmark_extension_api.h cmark_parser_attach_syntax_extension
     c_cmark_parser_attach_syntax_extension :: ParserPtr -> ExtensionPtr -> IO ()
 
 foreign import ccall "strikethrough.h &CMARK_NODE_STRIKETHROUGH"
-    c_CMARK_NODE_STRIKETHROUGH :: Ptr CUShort
+    c_CMARK_NODE_STRIKETHROUGH :: Ptr #type cmark_node_type
 
 foreign import ccall "table.h &CMARK_NODE_TABLE"
-    c_CMARK_NODE_TABLE :: Ptr CUShort
+    c_CMARK_NODE_TABLE :: Ptr #type cmark_node_type
 
 foreign import ccall "table.h &CMARK_NODE_TABLE_ROW"
-    c_CMARK_NODE_TABLE_ROW :: Ptr CUShort
+    c_CMARK_NODE_TABLE_ROW :: Ptr #type cmark_node_type
 
 foreign import ccall "table.h &CMARK_NODE_TABLE_CELL"
-    c_CMARK_NODE_TABLE_CELL :: Ptr CUShort
+    c_CMARK_NODE_TABLE_CELL :: Ptr #type cmark_node_type
 
 foreign import ccall "core-extensions.h cmarkextensions_get_table_columns"
     c_cmarkextensions_get_table_columns :: NodePtr -> IO CUShort


### PR DESCRIPTION
The storage type of an enum can be any integer type big enough to cover
the required range. Use the '#type' keyword of c2hs to derive the
correct storage type for the cmark_node_type enumeration.

Note that the previous use of CUShort produced incorrect results in big
endian architectures where 'sizeof(cmark_node_type) > sizeof(CUShort)'.

Closes #6: not big-endian-safe

Signed-off-by: Ilias Tsitsimpis <iliastsi@debian.org>