### PR TITLE
Follow cmark-gfm's new library name

### DIFF
--- a/cmark-gfm.cabal
+++ b/cmark-gfm.cabal
@@ -76,7 +76,7 @@ library
   default-language:    Haskell2010
   ghc-options:         -Wall -fno-warn-unused-do-bind
   if flag(pkgconfig)
-    Extra-Libraries: cmark-gfm cmark-gfmextensions
+    Extra-Libraries: cmark-gfm cmark-gfm-extensions
   else
     cc-options:        -Wall -std=c99
     Include-dirs:      cbits


### PR DESCRIPTION
The library got renamed in the new release, it would be nice to rename it here the same way :)