### PR TITLE
Allow text-2.0

### DIFF
--- a/cmark-gfm.cabal
+++ b/cmark-gfm.cabal
@@ -69,7 +69,7 @@ flag pkgconfig
 library
   exposed-modules:     CMarkGFM
   build-depends:       base >=4.5 && < 5.0,
-                       text >= 1.0 && < 1.3,
+                       text >= 1.0 && < 2.1,
                        bytestring
   if impl(ghc < 7.6)
     build-depends:     ghc-prim >= 0.2


### PR DESCRIPTION
Tested using

    cabal test --constraint='text>=2' -w ghc-9.0.2
