### PR TITLE
[#26] Footnotes support

### DIFF
--- a/test/test-cmark.hs
+++ b/test/test-cmark.hs
@@ -33,5 +33,6 @@ tests = TestList [
   , "<xmp>\n" ~=? commonmarkToHtml [optUnsafe] [] "<xmp>"
   , "&lt;xmp>\n" ~=? commonmarkToHtml [optUnsafe] [extTagfilter] "<xmp>"
   , "<ul>\n<li><input type=\"checkbox\" disabled=\"\" /> foo</li>\n<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> bar</li>\n</ul>\n" ~=? commonmarkToHtml [] [extTaskList] "- [ ] foo\n- [x] bar"
+  , "<p>Here is footnote<sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup></p>\n<section class=\"footnotes\" data-footnotes>\n<ol>\n<li id=\"fn-1\">\n<p>abc <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩</a></p>\n</li>\n</ol>\n</section>\n" ~=? commonmarkToHtml [optFootnotes] [] "Here is footnote[^1]\n\n[^1]: abc"
   ]
 


### PR DESCRIPTION
There is extension "footnotes" in cmark-gfm, that was unsupported by this lib
It extends a Node type with footnotes (like `[^1`)
I added `FOOTNOTE_DEFINITION` and `FOOTNOTE_REFERENCE`  to `Node`
Internally it is an option, so I exposed it as an option,
maybe it should be pseudo-extension instead