### PR TITLE
Make core-extension registration thread-safe

### DIFF
--- a/CMarkGFM.hsc
+++ b/CMarkGFM.hsc
@@ -51,13 +51,46 @@ import qualified Data.Text.Foreign as TF
 import Data.ByteString.Unsafe (unsafePackMallocCString)
 import Data.Text.Encoding (decodeUtf8)
 import Control.Applicative ((<$>), (<*>))
+import Control.Concurrent.MVar (MVar, newMVar, modifyMVar_)
 
 #include <cmark-gfm.h>
 #include <cmark-gfm-core-extensions.h>
 
--- | Ensure core extensions are registered.
+-- | Guards 'ensurePluginsRegistered'. 'False' until registration has run.
+{-# NOINLINE pluginRegistrationGuard #-}
+pluginRegistrationGuard :: MVar Bool
+pluginRegistrationGuard = Unsafe.unsafePerformIO (newMVar False)
+
+-- | Ensure core extensions are registered, exactly once, whatever thread asks.
+--
+-- The C function underneath guards itself with a plain @static int registered@
+-- check-then-set (@extensions\/core-extensions.c@) and is therefore not
+-- thread-safe. Two threads can both observe it unregistered and both call
+-- @cmark_register_plugin@, whereupon @create_table_extension@ calls
+-- @cmark_register_node_flag@ a second time on the already-initialised global
+-- @CMARK_NODE__TABLE_VISITED@. That function's response to a non-zero flag is
+-- to print @flag initialization error in cmark_register_node_flag@ and
+-- @abort()@ the process -- so the symptom is SIGABRT, not an exception a caller
+-- could catch. (@cmark_register_plugin@ also appends to the global
+-- @syntax_extensions@ list unguarded, a second race that merely happens to be
+-- silent.)
+--
+-- Every entry point that resolves extensions calls this, including with an
+-- empty extension list, and the exported API is pure --- 'commonmarkToNode' is
+-- 'Unsafe.unsafePerformIO' --- so nothing stops a caller from parsing on
+-- several threads at once. Serializing is therefore this binding's job, not the
+-- caller's.
+--
+-- A @NOINLINE@ CAF would not be enough: GHC's lazy blackholing permits two
+-- threads to enter the same thunk, which is the exact scenario being prevented.
 ensurePluginsRegistered :: IO ()
-ensurePluginsRegistered = c_cmark_gfm_core_extensions_ensure_registered
+ensurePluginsRegistered =
+  modifyMVar_ pluginRegistrationGuard $ \registered ->
+    if registered
+      then return True
+      else do
+        c_cmark_gfm_core_extensions_ensure_registered
+        return True
 
 -- | Frees a cmark linked list, produced by extsToLlist.
 freeLlist :: LlistPtr a -> IO ()

--- a/changelog
+++ b/changelog
@@ -2,6 +2,29 @@ cmark-gfm 0.2.7 (unreleased)
 
   * Pull in upstream changes.
 
+  * FORK: make core-extension registration thread-safe.
+
+    Every parse entry point calls ensurePluginsRegistered, including with an
+    empty extension list, and the exported API is pure (commonmarkToNode is
+    unsafePerformIO), so callers can and do parse on several threads at once.
+    The C function underneath guards itself with a plain `static int
+    registered` check-then-set, so two threads could both register; the second
+    registration calls cmark_register_node_flag on the already-initialised
+    global CMARK_NODE__TABLE_VISITED, which prints "flag initialization error
+    in cmark_register_node_flag" and abort()s the process.
+
+    ensurePluginsRegistered now serializes on an MVar and runs the C call
+    exactly once. A NOINLINE CAF would not do: GHC's lazy blackholing permits
+    two threads to enter one thunk.
+
+    Measured on a 16-thread reproducer, 20 runs each: stock aborted 7/20,
+    patched 0/20. The test suite gained a regression case and -with-rtsopts=-N
+    so it has real parallelism to race over; a regression shows up as the
+    suite dying with exit code 134, since SIGABRT is not catchable.
+
+    Not upstreamed yet. See mori://kivikakk/cmark-gfm-hs upstream-issues entry
+    `cmark-gfm-hs-unsafe-concurrent-extension-registration`.
+
 cmark 0.7 (08 Jul 2023)
 
   * Allow text 2.

--- a/cmark-gfm.cabal
+++ b/cmark-gfm.cabal
@@ -118,5 +118,5 @@ Test-Suite test-cmark-gfm
   main-is:        test-cmark.hs
   hs-source-dirs: test
   build-depends:  base, cmark-gfm, text, HUnit >= 1.2 && < 1.7
-  ghc-options:    -Wall -fno-warn-unused-do-bind -threaded
+  ghc-options:    -Wall -fno-warn-unused-do-bind -threaded -with-rtsopts=-N
   default-language: Haskell2010

--- a/test/test-cmark.hs
+++ b/test/test-cmark.hs
@@ -3,7 +3,11 @@
 import CMarkGFM
 import Test.HUnit
 import System.Exit
-import Data.Text ()
+import Control.Concurrent (forkIO)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.Exception (evaluate)
+import Control.Monad (forM)
+import Data.Text (pack)
 
 main :: IO ()
 main = do
@@ -11,6 +15,35 @@ main = do
   case (errors counts' + failures counts') of
        0 -> exitWith ExitSuccess
        n -> exitWith (ExitFailure n)
+
+-- | Parsing from several threads at once must not kill the process.
+--
+-- Every parse entry point resolves extensions first, which registers cmark's
+-- core extension plugins. That registration is guarded in C by a plain
+-- @static int registered@ check-then-set, so two threads could both find it
+-- unregistered and both register; the second registration calls
+-- @cmark_register_node_flag@ on an already-initialised global, which prints
+-- @flag initialization error in cmark_register_node_flag@ and @abort()@s.
+--
+-- The failure is SIGABRT rather than an exception, so this test cannot assert
+-- on it: a regression takes the whole suite down with exit code 134 instead of
+-- reporting a failed case. That is the intended signal.
+--
+-- Each thread parses a different document on purpose. Sharing one would let
+-- GHC share a single thunk, and then only one thread would ever enter
+-- 'commonmarkToNode'.
+concurrentRegistration :: Test
+concurrentRegistration = TestCase $ do
+  dones <- forM [1 .. 16 :: Int] $ \i -> do
+    done <- newEmptyMVar
+    _ <- forkIO $ do
+      n <- evaluate (length (show (commonmarkToNode [optFootnotes] [] (doc i))))
+      putMVar done n
+    return done
+  parsed <- mapM takeMVar dones
+  assertBool "every concurrent parse produced a node" (all (> 0) parsed)
+  where
+    doc i = pack ("# doc " ++ show i ++ "\n\nbody[^a]\n\n[^a]: def\n")
 
 -- The C library has its own extensive tests.
 -- Here we just make sure it's basically working.
@@ -37,5 +70,6 @@ tests = TestList [
   , Node (Just (PosInfo {startLine = 1, startColumn = 1, endLine = 1, endColumn = 11})) DOCUMENT [Node (Just (PosInfo {startLine = 1, startColumn = 1, endLine = 1, endColumn = 11})) (LIST (ListAttributes {listType = BULLET_LIST, listTight = True, listStart = 0, listDelim = PERIOD_DELIM})) [Node (Just (PosInfo {startLine = 1, startColumn = 1, endLine = 1, endColumn = 11})) (TASKLIST False) [Node (Just (PosInfo {startLine = 1, startColumn = 7, endLine = 1, endColumn = 11})) PARAGRAPH [Node (Just (PosInfo {startLine = 1, startColumn = 7, endLine = 1, endColumn = 11})) (TEXT "hello") []]]]] ~=? commonmarkToNode [] [extTaskList] "- [ ] hello"
   , Node (Just (PosInfo {startLine = 1, startColumn = 1, endLine = 1, endColumn = 11})) DOCUMENT [Node (Just (PosInfo {startLine = 1, startColumn = 1, endLine = 1, endColumn = 11})) (LIST (ListAttributes {listType = BULLET_LIST, listTight = True, listStart = 0, listDelim = PERIOD_DELIM})) [Node (Just (PosInfo {startLine = 1, startColumn = 1, endLine = 1, endColumn = 11})) ITEM [Node (Just (PosInfo {startLine = 1, startColumn = 3, endLine = 1, endColumn = 11})) PARAGRAPH [Node (Just (PosInfo {startLine = 1, startColumn = 3, endLine = 1, endColumn = 11})) (TEXT "[ ] hello") []]]]] ~=? commonmarkToNode [] [] "- [ ] hello"
   , "- [x] hello\n" ~=? nodeToCommonmark [] Nothing (Node (Just (PosInfo {startLine = 1, startColumn = 1, endLine = 1, endColumn = 11})) DOCUMENT [Node (Just (PosInfo {startLine = 1, startColumn = 1, endLine = 1, endColumn = 11})) (LIST (ListAttributes {listType = BULLET_LIST, listTight = True, listStart = 0, listDelim = PERIOD_DELIM})) [Node (Just (PosInfo {startLine = 1, startColumn = 1, endLine = 1, endColumn = 11})) (TASKLIST True) [Node (Just (PosInfo {startLine = 1, startColumn = 7, endLine = 1, endColumn = 11})) PARAGRAPH [Node (Just (PosInfo {startLine = 1, startColumn = 7, endLine = 1, endColumn = 11})) (TEXT "hello") []]]]])
+  , concurrentRegistration
   ]
 


### PR DESCRIPTION
Parsing from two threads at once can kill the process:

```
flag initialization error in cmark_register_node_flag
```

then `abort()`. It's SIGABRT, so nothing catches or reports it — a test suite
that hits it just exits 134 with an empty log.

I've hit this in test suites across a few projects and worked around it each
time. I now have a multithreaded path that isn't a test, so I had Claude Code
help me track down the actual cause. This is the patch that fixed it.

## Mechanism

1. `resolveExts` (`CMarkGFM.hsc:77`) calls `ensurePluginsRegistered` *before*
   looking at its argument, so even `commonmarkToNode [] []` registers.
2. The C guard (`cbits/core-extensions.c:20`) is a non-atomic
   `static int registered` check-then-set — two threads can both register.
3. The second registration reaches `create_table_extension`
   (`cbits/table.c:856`), which calls
   `cmark_register_node_flag(&CMARK_NODE__TABLE_VISITED)`.
4. That function aborts on an already-set flag (`cbits/node.c:22`). Its own
   comment says it "should only be called once"; nothing enforces that.

(`cmark_register_plugin` also appends to the global `syntax_extensions` list
unguarded — same cause, silent instead of fatal.)

## Fix

`ensurePluginsRegistered` now serializes on an `MVar` and runs the C call once.

A `NOINLINE` CAF isn't enough — GHC's lazy blackholing lets two threads enter one
thunk, which is the exact case being prevented.

I put this in the binding rather than the C because the binding is what creates
the concurrency: `commonmarkToNode` is `unsafePerformIO` behind a pure signature,
so callers have no way to know serialization is required. Happy to do it in C
with `pthread_once` instead if you'd prefer.

Nothing exported changes type or behaviour (`ensurePluginsRegistered` is
internal). Single-threaded callers get one uncontended `MVar` take/put on a path
that already enters C.

## Measurements

16 threads each parsing a different document, 20 runs, GHC 9.12.4
aarch64-darwin: **7/20 aborts before, 0/20 after**.

## Testing

`cabal test` passes. Added a regression case plus `-with-rtsopts=-N` — without
the RTS flag there's no real parallelism to race over. The case can't assert on
the failure (SIGABRT kills the process first); a regression shows up as the suite
exiting 134, which is noted in a comment so it isn't mistaken for CI flakiness.
